### PR TITLE
Create dependabot.yml 🔑

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
A little bit of background:

Dependabot is a github bot that keeps dependencies updated.

In conjuntion with a good continous integration system it will create a time saving system for keep your project in a sane state.

After this commit is merged into the master/main branch, the dependabot is triggered and it will create several PR in order to update the project.

If that PR becomes the project broken it will be catch by the CI system and you need to investigate why that PR is breaking the project.

Thanks for opening to the public this project.

PS: you can see the result of dependabot in my repo:
https://github.com/mercuriete/radar-covid-android/pulls

```
Bump rootProject.daggerVersion from 2.27 to 2.28.3 dependencies

Bump mockito-core from 3.5.6 to 3.5.10 dependencies

Bump material from 1.2.0 to 1.2.1 dependencies

Bump dp3t-sdk-android from 1.0.3 to 1.0.4-dev-2-calibration dependencies

Bump gradle from 3.6.4 to 4.0.1 dependencies
```

PS2: this PR probably depends on #17 because CI is not working at this time