### PR TITLE
Fix minor typo in API method

### DIFF
--- a/app/src/main/java/es/gob/radarcovid/datamanager/api/ApiInterface.kt
+++ b/app/src/main/java/es/gob/radarcovid/datamanager/api/ApiInterface.kt
@@ -76,7 +76,7 @@ interface ApiInterface {
     ): Call<String>
 
     @Headers("Accept: application/x-protobuf")
-    @GET("/notifyme/v1/traceKeys ")
+    @GET("/notifyme/v1/traceKeys")
     fun getTraceKeys(
         @Query("keyBundleTag") keyBundleTag: Long
     ): Call<ResponseBody>


### PR DESCRIPTION
- Removed trailing space in ApiInterface